### PR TITLE
feat: serve ai to agents

### DIFF
--- a/apps/web/src/app/(forum)/thread/[...id]/_components/continue-discussion.tsx
+++ b/apps/web/src/app/(forum)/thread/[...id]/_components/continue-discussion.tsx
@@ -1,1 +1,0 @@
-export { ContinueDiscussion } from "@/components/forum/continue-discussion";

--- a/apps/web/src/app/(forum)/thread/[...id]/_components/message-highlight.tsx
+++ b/apps/web/src/app/(forum)/thread/[...id]/_components/message-highlight.tsx
@@ -1,5 +1,0 @@
-export {
-	HashProvider,
-	MessageHighlight,
-	useHash,
-} from "@/components/forum/thread-message-highlight";

--- a/apps/web/src/app/(forum)/thread/[...id]/_components/thread-message.tsx
+++ b/apps/web/src/app/(forum)/thread/[...id]/_components/thread-message.tsx
@@ -1,1 +1,0 @@
-export { anonymizeName, MessagePost } from "@/components/forum/thread-message";

--- a/apps/web/src/app/(forum)/thread/[threadId]/[slug]/page.tsx
+++ b/apps/web/src/app/(forum)/thread/[threadId]/[slug]/page.tsx
@@ -14,7 +14,7 @@ import { snowflakeToReadableDate } from "@repo/utils/helpers/time";
 import { ChannelType } from "discord-api-types/v10";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound, redirect } from "next/navigation";
+import { notFound, permanentRedirect, redirect } from "next/navigation";
 import { JsonLd } from "react-schemaorg";
 import type { DiscussionForumPosting, WithContext } from "schema-dts";
 import { ContinueDiscussion } from "@/components/forum/continue-discussion";
@@ -24,26 +24,33 @@ import { HashProvider } from "@/components/forum/thread-message-highlight";
 import type { ThreadMessagesWithMetadata } from "@/components/forum/thread-types";
 import { ThreadIcon } from "@/components/markdown/mention";
 import ThreadFeedback from "@/components/thread-feedback";
-import { getCustomDomainUrl } from "@/lib/domains";
+import {
+	getCustomDomainUrl,
+	getMainSiteUrl,
+	getThreadPath,
+	hasVerifiedCustomDomain,
+} from "@/lib/domains";
 import { buildDiscussionMetadata, buildRobots, toDescription } from "@/lib/seo";
 import { ThreadProvider } from "@/providers/use-thread";
+import { getAllMessagesInThreadsCache } from "@/utils/cache";
 import { sanitizeJsonLd } from "@/utils/sanitize";
-import { getTenantThreadOrNotFound } from "../../_lib/tenant";
 
 type PageProps = {
-	params: Promise<{ domain: string; id: [string, string?, string?] }>;
+	params: Promise<{ threadId: string; slug: string }>;
 };
 
 export async function generateMetadata({
 	params,
 }: PageProps): Promise<Metadata> {
-	const {
-		domain,
-		id: [threadId, slug],
-	} = await params;
-	const { server, thread } = await getTenantThreadOrNotFound(domain, threadId);
+	const { threadId, slug } = await params;
 
-	if (!thread.messages.length || !thread.channelName) {
+	const thread = await getAllMessagesInThreadsCache(threadId);
+
+	if (
+		!thread?.messages ||
+		thread.messages.length === 0 ||
+		!thread.channelName
+	) {
 		return {
 			title: "Thread not found",
 			robots: {
@@ -53,9 +60,9 @@ export async function generateMetadata({
 		};
 	}
 
-	const url = slugifyThreadUrl({ id: threadId, name: thread.channelName });
-	const canonicalUrl = getCustomDomainUrl(server, url);
-	const hasSlug = slug && slug === getSlugFromTitle(thread.channelName);
+	const url = slugifyThreadUrl({ id: threadId, name: thread.channelName! });
+	const canonicalUrl = getMainSiteUrl(url);
+	const hasSlug = slug === getSlugFromTitle(thread.channelName!);
 
 	return buildDiscussionMetadata({
 		title: thread.channelName,
@@ -75,40 +82,37 @@ export async function generateMetadata({
 }
 
 export default async function Page({ params }: PageProps) {
-	const {
-		domain,
-		id: [threadId, slug, markdown],
-	} = await params;
-
-	if (markdown) {
-		redirect(`/markdown/${threadId}`);
-	}
+	const { threadId, slug } = await params;
 
 	if (!threadId) {
 		notFound();
 	}
 
-	const { server, thread } = await getTenantThreadOrNotFound(domain, threadId);
+	const thread = await getAllMessagesInThreadsCache(threadId);
+
+	if (!thread?.server) {
+		notFound();
+	}
+
+	if (hasVerifiedCustomDomain(thread.server)) {
+		const targetPath = getThreadPath(threadId, thread.channelName!);
+		permanentRedirect(getCustomDomainUrl(thread.server, targetPath));
+	}
 
 	const threadUrlWithSlug = slugifyThreadUrl({
 		id: threadId,
 		name: thread.channelName!,
 	});
-	const canonicalUrl = getCustomDomainUrl(server, threadUrlWithSlug);
-	if (!slug || slug !== getSlugFromTitle(thread.channelName!)) {
+	if (slug !== getSlugFromTitle(thread.channelName!)) {
 		redirect(threadUrlWithSlug);
 	}
 
+	const server = thread.server;
+
 	const [originalPost, ...orderedMessages] = thread.messages;
-	if (!originalPost) {
-		notFound();
-	}
 
 	const items = [
-		...orderedMessages.map((message) => ({
-			type: "message" as const,
-			data: message,
-		})),
+		...orderedMessages.map((msg) => ({ type: "message" as const, data: msg })),
 		...thread.backlinks.map((backlink) => ({
 			type: "backlink" as const,
 			data: {
@@ -118,20 +122,27 @@ export default async function Page({ params }: PageProps) {
 		})),
 	].sort((a, b) => a.data.id.localeCompare(b.data.id));
 
+	if (!originalPost) {
+		notFound();
+	}
+
 	const op = originalPost.user!;
 	const title = thread.channelName ?? originalPost.content?.slice(0, 100);
 	const firstImage = originalPost.attachments
-		.filter((attachment) => getEmbedFileInfo(attachment).type === "image")
+		.filter((a) => getEmbedFileInfo(a).type === "image")
 		.at(0);
+
 	const authorId = thread.messages[0]?.user?.id;
 	const dateModified = thread.messages
-		.map((message) => message.id)
-		.reduce((snowflake, nextSnowflake) =>
-			BigInt(snowflake) > BigInt(nextSnowflake) ? snowflake : nextSnowflake,
+		.map((m) => m.id)
+		.reduce((snowflake, snowflake2) =>
+			BigInt(snowflake) > BigInt(snowflake2) ? snowflake : snowflake2,
 		);
+
 	const messagesLookup = new Map<string, ThreadMessagesWithMetadata>(
-		thread.messages.map((message) => [message.id, message]),
+		thread.messages.map((x) => [x.id, x]),
 	);
+	const canonicalUrl = getMainSiteUrl(threadUrlWithSlug);
 
 	return (
 		<div>
@@ -156,48 +167,52 @@ export default async function Page({ params }: PageProps) {
 						articleBody: originalPost.content,
 						identifier: thread.id,
 						commentCount: orderedMessages.length,
-						comment: orderedMessages.map((message, index) => ({
+						comment: orderedMessages.map((m, idx) => ({
 							"@type": "Comment",
-							text: message.content,
-							identifier: message.id,
-							datePublished: getDateFromSnowflake(message.id).toISOString(),
-							position: index + 1,
+							text: m.content,
+							identifier: m.id,
+							datePublished: getDateFromSnowflake(m.id).toISOString(),
+							position: idx + 1,
 							author: {
 								"@type": "Person",
-								name: anonymizeName(message.user!),
+								name: anonymizeName(m.user!),
 								url: undefined,
-								identifier: message.user?.anonymizeName
-									? anonymizeName(message.user!)
-									: message.user?.id,
+								identifier: m.user?.anonymizeName
+									? anonymizeName(m.user!)
+									: m.user?.id,
 							},
 						})),
 					})}
 				/>
-				<div className="my-6 px-3">
-					<h1 className="my-2 max-w-4xl truncate text-balance font-medium text-3xl tracking-tight lg:text-4xl">
-						{thread.channelName}
-					</h1>
-					<Link
-						className="flex w-fit items-center gap-1 bg-purple-100 px-2 py-0.5 text-purple-700 text-sm transition-all hover:bg-purple-200"
-						href={`/channel/${thread.parentId}`}
-					>
-						{thread.parent?.type === ChannelType.GuildForum ? (
-							<ChatsCircleIcon className="size-3.5" />
-						) : (
-							<HashIcon className="size-3.5" weight="bold" />
-						)}
-						{thread.parent?.channelName}
-					</Link>
+				<div>
+					<div className="my-6 px-3">
+						<h1 className="my-2 max-w-4xl text-balance truncate font-medium text-3xl tracking-tight lg:text-4xl">
+							{thread.channelName}
+						</h1>
+						<Link
+							className="flex w-fit items-center gap-1 bg-purple-100 px-2 py-0.5 text-purple-700 text-sm transition-all hover:bg-purple-200 "
+							href={`/channel/${thread.parentId}`}
+						>
+							{thread.parent?.type === ChannelType.GuildForum ? (
+								<ChatsCircleIcon className="size-3.5" />
+							) : (
+								<HashIcon className="size-3.5" weight="bold" />
+							)}
+							{thread.parent?.channelName}
+						</Link>
+					</div>
 				</div>
 				<HashProvider>
 					<div className="flex flex-col gap-6 overflow-hidden md:flex-row">
 						<div className="flex-1 overflow-hidden">
-							<MessagePost
-								authorId={authorId!}
-								isOriginalPost={true}
-								key={originalPost.id}
-								message={originalPost}
-							/>
+							{originalPost !== undefined && (
+								<MessagePost
+									authorId={authorId!}
+									isOriginalPost={true}
+									key={originalPost?.id}
+									message={originalPost!}
+								/>
+							)}
 							<div className="my-4 flex items-center gap-2 px-3">
 								<ChatIcon className="size-5" />
 								<span className="text-sm">
@@ -218,10 +233,10 @@ export default async function Page({ params }: PageProps) {
 											/>
 										);
 									}
-
 									return (
 										<div className="relative flex gap-3 p-4" key={item.data.id}>
 											<div className="-my-2 absolute top-0 bottom-0 left-7.5 w-0.5 bg-neutral-200" />
+
 											<div className="relative z-10 flex size-8 shrink-0 items-center justify-center rounded-full bg-white ring-2 ring-neutral-200">
 												<ThreadIcon className="size-4 text-neutral-700" />
 											</div>
@@ -266,7 +281,7 @@ export default async function Page({ params }: PageProps) {
 							/>
 						</div>
 						<div className="hidden w-full max-w-xs space-y-6 md:block">
-							<ServerInfo homeHref="/" server={server} />
+							<ServerInfo homeHref={`/server/${server.id}`} server={server} />
 							<ThreadFeedback />
 						</div>
 					</div>

--- a/apps/web/src/app/[domain]/thread/[...id]/_components/continue-discussion.tsx
+++ b/apps/web/src/app/[domain]/thread/[...id]/_components/continue-discussion.tsx
@@ -1,1 +1,0 @@
-export { ContinueDiscussion } from "@/components/forum/continue-discussion";

--- a/apps/web/src/app/[domain]/thread/[...id]/_components/message-highlight.tsx
+++ b/apps/web/src/app/[domain]/thread/[...id]/_components/message-highlight.tsx
@@ -1,5 +1,0 @@
-export {
-	HashProvider,
-	MessageHighlight,
-	useHash,
-} from "@/components/forum/thread-message-highlight";

--- a/apps/web/src/app/[domain]/thread/[...id]/_components/thread-message.tsx
+++ b/apps/web/src/app/[domain]/thread/[...id]/_components/thread-message.tsx
@@ -1,1 +1,0 @@
-export { anonymizeName, MessagePost } from "@/components/forum/thread-message";

--- a/apps/web/src/app/[domain]/thread/[threadId]/[slug]/page.tsx
+++ b/apps/web/src/app/[domain]/thread/[threadId]/[slug]/page.tsx
@@ -14,7 +14,7 @@ import { snowflakeToReadableDate } from "@repo/utils/helpers/time";
 import { ChannelType } from "discord-api-types/v10";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound, permanentRedirect, redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { JsonLd } from "react-schemaorg";
 import type { DiscussionForumPosting, WithContext } from "schema-dts";
 import { ContinueDiscussion } from "@/components/forum/continue-discussion";
@@ -24,35 +24,23 @@ import { HashProvider } from "@/components/forum/thread-message-highlight";
 import type { ThreadMessagesWithMetadata } from "@/components/forum/thread-types";
 import { ThreadIcon } from "@/components/markdown/mention";
 import ThreadFeedback from "@/components/thread-feedback";
-import {
-	getCustomDomainUrl,
-	getMainSiteUrl,
-	getThreadPath,
-	hasVerifiedCustomDomain,
-} from "@/lib/domains";
+import { getCustomDomainUrl } from "@/lib/domains";
 import { buildDiscussionMetadata, buildRobots, toDescription } from "@/lib/seo";
 import { ThreadProvider } from "@/providers/use-thread";
-import { getAllMessagesInThreadsCache } from "@/utils/cache";
 import { sanitizeJsonLd } from "@/utils/sanitize";
+import { getTenantThreadOrNotFound } from "../../../_lib/tenant";
 
 type PageProps = {
-	params: Promise<{ id: [string, string?, string?] }>;
+	params: Promise<{ domain: string; threadId: string; slug: string }>;
 };
 
 export async function generateMetadata({
 	params,
 }: PageProps): Promise<Metadata> {
-	const {
-		id: [threadId, slug],
-	} = await params;
+	const { domain, threadId, slug } = await params;
+	const { server, thread } = await getTenantThreadOrNotFound(domain, threadId);
 
-	const thread = await getAllMessagesInThreadsCache(threadId);
-
-	if (
-		!thread?.messages ||
-		thread.messages.length === 0 ||
-		!thread.channelName
-	) {
+	if (!thread.messages.length || !thread.channelName) {
 		return {
 			title: "Thread not found",
 			robots: {
@@ -62,9 +50,9 @@ export async function generateMetadata({
 		};
 	}
 
-	const url = slugifyThreadUrl({ id: threadId, name: thread.channelName! });
-	const canonicalUrl = getMainSiteUrl(url);
-	const hasSlug = slug && slug === getSlugFromTitle(thread.channelName!);
+	const url = slugifyThreadUrl({ id: threadId, name: thread.channelName });
+	const canonicalUrl = getCustomDomainUrl(server, url);
+	const hasSlug = slug === getSlugFromTitle(thread.channelName);
 
 	return buildDiscussionMetadata({
 		title: thread.channelName,
@@ -84,45 +72,33 @@ export async function generateMetadata({
 }
 
 export default async function Page({ params }: PageProps) {
-	const {
-		id: [threadId, slug, markdown],
-	} = await params;
-
-	if (markdown) {
-		redirect(`/markdown/${threadId}`);
-	}
+	const { domain, threadId, slug } = await params;
 
 	if (!threadId) {
 		notFound();
 	}
 
-	const thread = await getAllMessagesInThreadsCache(threadId);
-
-	if (!thread?.server) {
-		notFound();
-	}
-
-	if (hasVerifiedCustomDomain(thread.server)) {
-		const targetPath = markdown
-			? `/markdown/${threadId}`
-			: getThreadPath(threadId, thread.channelName!);
-		permanentRedirect(getCustomDomainUrl(thread.server, targetPath));
-	}
+	const { server, thread } = await getTenantThreadOrNotFound(domain, threadId);
 
 	const threadUrlWithSlug = slugifyThreadUrl({
 		id: threadId,
 		name: thread.channelName!,
 	});
-	if (!slug || slug !== getSlugFromTitle(thread.channelName!)) {
+	const canonicalUrl = getCustomDomainUrl(server, threadUrlWithSlug);
+	if (slug !== getSlugFromTitle(thread.channelName!)) {
 		redirect(threadUrlWithSlug);
 	}
 
-	const server = thread.server;
-
 	const [originalPost, ...orderedMessages] = thread.messages;
+	if (!originalPost) {
+		notFound();
+	}
 
 	const items = [
-		...orderedMessages.map((msg) => ({ type: "message" as const, data: msg })),
+		...orderedMessages.map((message) => ({
+			type: "message" as const,
+			data: message,
+		})),
 		...thread.backlinks.map((backlink) => ({
 			type: "backlink" as const,
 			data: {
@@ -132,28 +108,20 @@ export default async function Page({ params }: PageProps) {
 		})),
 	].sort((a, b) => a.data.id.localeCompare(b.data.id));
 
-	if (!originalPost) {
-		notFound();
-	}
-
 	const op = originalPost.user!;
 	const title = thread.channelName ?? originalPost.content?.slice(0, 100);
 	const firstImage = originalPost.attachments
-		.filter((a) => getEmbedFileInfo(a).type === "image")
+		.filter((attachment) => getEmbedFileInfo(attachment).type === "image")
 		.at(0);
-
-	// TODO: handle empty messages;
 	const authorId = thread.messages[0]?.user?.id;
 	const dateModified = thread.messages
-		.map((m) => m.id)
-		.reduce((snowflake, snowflake2) =>
-			BigInt(snowflake) > BigInt(snowflake2) ? snowflake : snowflake2,
+		.map((message) => message.id)
+		.reduce((snowflake, nextSnowflake) =>
+			BigInt(snowflake) > BigInt(nextSnowflake) ? snowflake : nextSnowflake,
 		);
-
 	const messagesLookup = new Map<string, ThreadMessagesWithMetadata>(
-		thread.messages.map((x) => [x.id, x]),
+		thread.messages.map((message) => [message.id, message]),
 	);
-	const canonicalUrl = getMainSiteUrl(threadUrlWithSlug);
 
 	return (
 		<div>
@@ -171,7 +139,6 @@ export default async function Page({ params }: PageProps) {
 							url: undefined,
 							identifier: op.anonymizeName ? anonymizeName(op) : op?.id,
 						},
-						// todo fall to an og?
 						image:
 							firstImage?.proxyURL ||
 							new URL(`/og?id=${thread.id}`, canonicalUrl).toString(),
@@ -179,53 +146,48 @@ export default async function Page({ params }: PageProps) {
 						articleBody: originalPost.content,
 						identifier: thread.id,
 						commentCount: orderedMessages.length,
-						comment: orderedMessages.map((m, idx) => ({
+						comment: orderedMessages.map((message, index) => ({
 							"@type": "Comment",
-							text: m.content,
-							identifier: m.id,
-							// TODO: add parentItem
-							datePublished: getDateFromSnowflake(m.id).toISOString(),
-							position: idx + 1,
+							text: message.content,
+							identifier: message.id,
+							datePublished: getDateFromSnowflake(message.id).toISOString(),
+							position: index + 1,
 							author: {
 								"@type": "Person",
-								name: anonymizeName(m.user!),
+								name: anonymizeName(message.user!),
 								url: undefined,
-								identifier: m.user?.anonymizeName
-									? anonymizeName(m.user!)
-									: m.user?.id,
+								identifier: message.user?.anonymizeName
+									? anonymizeName(message.user!)
+									: message.user?.id,
 							},
 						})),
 					})}
 				/>
-				<div>
-					<div className="my-6 px-3">
-						<h1 className="my-2 max-w-4xl text-balance font-medium text-3xl tracking-tight lg:text-4xl truncate">
-							{thread.channelName}
-						</h1>
-						<Link
-							className="flex w-fit items-center gap-1 px-2 py-0.5 text-purple-700 text-sm transition-all bg-purple-100 hover:bg-purple-200 "
-							href={`/channel/${thread.parentId}`}
-						>
-							{thread.parent?.type === ChannelType.GuildForum ? (
-								<ChatsCircleIcon className="size-3.5" />
-							) : (
-								<HashIcon className="size-3.5" weight="bold" />
-							)}
-							{thread.parent?.channelName}
-						</Link>
-					</div>
+				<div className="my-6 px-3">
+					<h1 className="my-2 max-w-4xl truncate text-balance font-medium text-3xl tracking-tight lg:text-4xl">
+						{thread.channelName}
+					</h1>
+					<Link
+						className="flex w-fit items-center gap-1 bg-purple-100 px-2 py-0.5 text-purple-700 text-sm transition-all hover:bg-purple-200"
+						href={`/channel/${thread.parentId}`}
+					>
+						{thread.parent?.type === ChannelType.GuildForum ? (
+							<ChatsCircleIcon className="size-3.5" />
+						) : (
+							<HashIcon className="size-3.5" weight="bold" />
+						)}
+						{thread.parent?.channelName}
+					</Link>
 				</div>
 				<HashProvider>
 					<div className="flex flex-col gap-6 overflow-hidden md:flex-row">
 						<div className="flex-1 overflow-hidden">
-							{originalPost !== undefined && (
-								<MessagePost
-									authorId={authorId!}
-									isOriginalPost={true}
-									key={originalPost?.id}
-									message={originalPost!}
-								/>
-							)}
+							<MessagePost
+								authorId={authorId!}
+								isOriginalPost={true}
+								key={originalPost.id}
+								message={originalPost}
+							/>
 							<div className="my-4 flex items-center gap-2 px-3">
 								<ChatIcon className="size-5" />
 								<span className="text-sm">
@@ -246,10 +208,10 @@ export default async function Page({ params }: PageProps) {
 											/>
 										);
 									}
+
 									return (
 										<div className="relative flex gap-3 p-4" key={item.data.id}>
 											<div className="-my-2 absolute top-0 bottom-0 left-7.5 w-0.5 bg-neutral-200" />
-
 											<div className="relative z-10 flex size-8 shrink-0 items-center justify-center rounded-full bg-white ring-2 ring-neutral-200">
 												<ThreadIcon className="size-4 text-neutral-700" />
 											</div>
@@ -294,7 +256,7 @@ export default async function Page({ params }: PageProps) {
 							/>
 						</div>
 						<div className="hidden w-full max-w-xs space-y-6 md:block">
-							<ServerInfo homeHref={`/server/${server.id}`} server={server} />
+							<ServerInfo homeHref="/" server={server} />
 							<ThreadFeedback />
 						</div>
 					</div>

--- a/apps/web/src/components/forum/markdown.ts
+++ b/apps/web/src/components/forum/markdown.ts
@@ -75,6 +75,7 @@ export function MarkdownResponse(content: string): Response {
 	return new Response(content, {
 		headers: {
 			"Content-Type": "text/markdown; charset=utf-8",
+			Vary: "Accept",
 		},
 	});
 }

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { acceptsMarkdown, getMarkdownThreadRewrite } from "@/proxy";
+
+describe("proxy markdown routing", () => {
+	it("detects markdown accept headers", () => {
+		expect(acceptsMarkdown("text/html, text/markdown;q=0.9")).toBe(true);
+		expect(acceptsMarkdown("text/html,application/xhtml+xml")).toBe(false);
+	});
+
+	it("rewrites main-site thread requests for markdown accept", () => {
+		expect(
+			getMarkdownThreadRewrite(
+				"/thread/123/right_slug",
+				"velumn.com",
+				"text/html, text/markdown;q=0.9",
+			),
+		).toEqual({ pathname: "/markdown/123" });
+	});
+
+	it("rewrites explicit markdown thread URLs on the main site", () => {
+		expect(
+			getMarkdownThreadRewrite("/thread/123/right_slug.md", "velumn.com", null),
+		).toEqual({ pathname: "/markdown/123" });
+	});
+
+	it("rewrites explicit markdown thread URLs on custom domains", () => {
+		expect(
+			getMarkdownThreadRewrite(
+				"/thread/123/right_slug.md",
+				"docs.example.com",
+				null,
+			),
+		).toEqual({ pathname: "/docs.example.com/markdown/123" });
+	});
+
+	it("ignores normal html thread requests", () => {
+		expect(
+			getMarkdownThreadRewrite(
+				"/thread/123/right_slug",
+				"velumn.com",
+				"text/html,application/xhtml+xml",
+			),
+		).toBeNull();
+	});
+});

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -33,6 +33,12 @@ describe("proxy markdown routing", () => {
 		).toEqual({ pathname: "/docs.example.com/markdown/123" });
 	});
 
+	it("falls back to the main-site markdown path when host is missing", () => {
+		expect(
+			getMarkdownThreadRewrite("/thread/123/right_slug.md", null, null),
+		).toEqual({ pathname: "/markdown/123" });
+	});
+
 	it("ignores normal html thread requests", () => {
 		expect(
 			getMarkdownThreadRewrite(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -24,7 +24,11 @@ export function proxy(request: NextRequest) {
 		return NextResponse.next();
 	}
 
-	const normalizedHost = normalizeHostHeader(host ?? "");
+	if (!host) {
+		return NextResponse.next();
+	}
+
+	const normalizedHost = normalizeHostHeader(host);
 	url.pathname = `/${normalizedHost}${url.pathname}`;
 	return NextResponse.rewrite(url);
 }
@@ -52,7 +56,11 @@ export function getMarkdownThreadRewrite(
 		return { pathname: markdownPath };
 	}
 
-	const normalizedHost = normalizeHostHeader(host ?? "");
+	if (!host) {
+		return { pathname: markdownPath };
+	}
+
+	const normalizedHost = normalizeHostHeader(host);
 	return {
 		pathname: `/${normalizedHost}${markdownPath}`,
 	};

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,6 +5,16 @@ export function proxy(request: NextRequest) {
 	const url = request.nextUrl;
 	const host = request.headers.get("host");
 	const pathname = url.pathname;
+	const markdownRewrite = getMarkdownThreadRewrite(
+		pathname,
+		host,
+		request.headers.get("accept"),
+	);
+
+	if (markdownRewrite) {
+		url.pathname = markdownRewrite.pathname;
+		return NextResponse.rewrite(url);
+	}
 
 	if (shouldBypassCustomDomainRewrite(pathname)) {
 		return NextResponse.next();
@@ -17,6 +27,43 @@ export function proxy(request: NextRequest) {
 	const normalizedHost = normalizeHostHeader(host ?? "");
 	url.pathname = `/${normalizedHost}${url.pathname}`;
 	return NextResponse.rewrite(url);
+}
+
+const THREAD_PATH_REGEX = /^\/thread\/([^/]+)\/([^/]+?)(\.md)?\/?$/;
+
+export function getMarkdownThreadRewrite(
+	pathname: string,
+	host: string | null | undefined,
+	accept: string | null | undefined,
+) {
+	const threadMatch = pathname.match(THREAD_PATH_REGEX);
+
+	if (!threadMatch) {
+		return null;
+	}
+
+	const [, threadId, , markdownSuffix] = threadMatch;
+	if (!markdownSuffix && !acceptsMarkdown(accept)) {
+		return null;
+	}
+
+	const markdownPath = `/markdown/${threadId}`;
+	if (isOnMainSite(host)) {
+		return { pathname: markdownPath };
+	}
+
+	const normalizedHost = normalizeHostHeader(host ?? "");
+	return {
+		pathname: `/${normalizedHost}${markdownPath}`,
+	};
+}
+
+export function acceptsMarkdown(accept: string | null | undefined) {
+	if (!accept) {
+		return false;
+	}
+
+	return accept.toLowerCase().includes("text/markdown");
 }
 
 function shouldBypassCustomDomainRewrite(pathname: string) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Thread routes simplified to explicit params (threadId, slug) and markdown-specific tuple handling removed
  * Cleaned up internal component export surfaces

* **New Features**
  * Server now negotiates markdown responses from thread URLs based on Accept headers and rewrites .md requests to markdown routes
  * Markdown responses include a Vary: Accept header

* **Tests**
  * Added tests covering proxy markdown routing and negotiation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->